### PR TITLE
Dockerfile: build psycopg2 in separate container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.1
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.1 as builder
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \
@@ -11,18 +11,30 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       build-essential \
       git \
-      vim \
-      nano \
+      # For Psycopg2
+      libpq-dev \
+      python3-dev \
+      python3-pip
+
+WORKDIR /build
+
+RUN python3.10 -m pip --disable-pip-version-check -q wheel --no-binary psycopg2 psycopg2
+
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.8.1
+
+# Apt installation
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+      git \
+      # For Psycopg2
+      libpq5 \
       tini \
-      wget \
       postgresql-client \
       python3-pip \
-      # For Psycopg2
-      libpq-dev python3-dev \
     && apt-get autoclean && \
     apt-get autoremove && \
     rm -rf /var/lib/{apt,dpkg,cache,log}
-
 
 # Environment can be whatever is supported by setup.py
 # so, either deployment, test
@@ -30,12 +42,16 @@ ARG ENVIRONMENT=deployment
 # ARG ENVIRONMENT=test
 
 RUN echo "Environment is: $ENVIRONMENT" && \
-    pip install pip-tools pytest-cov
+    [ "$ENVIRONMENT" = "deployment" ] || pip install pip-tools pytest-cov
 
 # Set up a nice workdir and add the live code
 ENV APPDIR=/code
 WORKDIR $APPDIR
 COPY . $APPDIR
+
+COPY --from=builder --link /build/*.whl ./
+RUN python3.10 -m pip --disable-pip-version-check -q install *.whl && \
+    rm *.whl
 
 # These ENVIRONMENT flags make this a bit complex, but basically, if we are in dev
 # then we want to link the source (with the -e flag) and if we're in prod, we


### PR DESCRIPTION
This avoids having to install development libraries in the production container, which makes the image ~300M smaller.

<!-- readthedocs-preview datacube-explorer start -->
----
:books: Documentation preview :books:: https://datacube-explorer--5.org.readthedocs.build/en/5/

<!-- readthedocs-preview datacube-explorer end -->